### PR TITLE
Fix/synonym letters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+*.log*
+.nuxt
+.nitro
+.cache
+.output
+.env
+dist
+.DS_Store
+.fleet
+.idea

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function convertToAmharic(text) {
   let convertedText = text;
   // Apply the transcription rules to convert the text to Amharic
   for (const rule in transcriptionRules) {
-    const regex = new RegExp(rule, "gi");
+    const regex = new RegExp(rule, 'g');
     convertedText = convertedText.replace(regex, transcriptionRules[rule]);
   }
 


### PR DESCRIPTION
### Amharic synonym letters are not being recognized

For instance:
- `e` prints `ዐ` instead of `አ`
- `N` prints `ን` instead of `ኝ`
- `H` prints `ህ` instead of `ሕ`
